### PR TITLE
fix(restapi): resolve broken markdown link breaking prod build

### DIFF
--- a/restapi/restendpoints.md
+++ b/restapi/restendpoints.md
@@ -1383,7 +1383,7 @@ This endpoint allows to Cancel/Void/Reverse a previous transaction without a rea
 | `Body: originalGuid` <span class="badge badge--primary">Required</span>   <br />*String*    | The GUID of the previously completed transaction to reverse. |
 | `Body: amount` <span class="badge badge--secondary">Optional</span>   <br />*String*    | Decimal amount in String, ISO 4217; Required for partial-reversals. *Only if your acquirer supports partial-reversals*. |
 | `Body: currency` <span class="badge badge--secondary">Optional</span>   <br />*String*    | Required for partial-reversals *Only if your acquirer supports partial-reversals*. |
-| `Body: messageReasonCode` <span class="badge badge--secondary">Optional</span>   <br />*String*    | default: CUSTOMER_CANCELLATION. See [allowed values](restapi/restobjects.md#messageReasonCode)|
+| `Body: messageReasonCode` <span class="badge badge--secondary">Optional</span>   <br />*String*    | default: CUSTOMER_CANCELLATION. See [allowed values](restobjects.md#messageReasonCode)|
 
 **Returns**
 

--- a/restapi_versioned_docs/version-REST API 2.28.0/restendpoints.md
+++ b/restapi_versioned_docs/version-REST API 2.28.0/restendpoints.md
@@ -1383,7 +1383,7 @@ This endpoint allows to Cancel/Void/Reverse a previous transaction without a rea
 | `Body: originalGuid` <span class="badge badge--primary">Required</span>   <br />*String*    | The GUID of the previously completed transaction to reverse. |
 | `Body: amount` <span class="badge badge--secondary">Optional</span>   <br />*String*    | Decimal amount in String, ISO 4217; Required for partial-reversals. *Only if your acquirer supports partial-reversals*. |
 | `Body: currency` <span class="badge badge--secondary">Optional</span>   <br />*String*    | Required for partial-reversals *Only if your acquirer supports partial-reversals*. |
-| `Body: messageReasonCode` <span class="badge badge--secondary">Optional</span>   <br />*String*    | default: CUSTOMER_CANCELLATION. See [allowed values](restapi/restobjects.md#messageReasonCode)|
+| `Body: messageReasonCode` <span class="badge badge--secondary">Optional</span>   <br />*String*    | default: CUSTOMER_CANCELLATION. See [allowed values](restobjects.md#messageReasonCode)|
 
 **Returns**
 


### PR DESCRIPTION
## Problem

The production deploy (`dev`→`main`) failed at `yarn deploy`:

```
Markdown link with URL `restapi/restobjects.md#messageReasonCode` in
"restapi_versioned_docs/version-REST API 2.28.0/restendpoints.md" (1386:140) couldn't be resolved.
```

[Failed run](https://github.com/handpoint/doc/actions/runs/28430201903/job/84242778123)

## Cause

Within a docs plugin, links must be relative to the plugin itself. Line 1386 used the `restapi/` prefix, which points outside the plugin and fails to resolve. With `onBrokenMarkdownLinks: 'throw'` this aborts the entire build. Introduced in `03a3924 restApi v2.28`.

## Fix

```diff
- See [allowed values](restapi/restobjects.md#messageReasonCode)|
+ See [allowed values](restobjects.md#messageReasonCode)|
```

Applied to both the live file and the versioned (2.28.0) copy.

## Verification

Local `yarn build` (with lockfile deps) → `[SUCCESS] Generated static files`. The remaining broken anchors are pre-existing warnings only and do not block the deploy.