### PR TITLE
fix: mobile touch events on cpdocs.js page

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -242,6 +242,12 @@ color: white;
   background: linear-gradient(248.33deg, #FFF5EB4d -6.24%, #EDE2DE4d 44.52%, #7A9BE84d 116.8%)!important;
 }
 
+/* iOS Safari: click events don't fire on non-interactive elements without cursor:pointer */
+.pills__item {
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
 /* Always-bold section group headings in the right-side TOC */
 .table-of-contents__link[href="#list-devices"],
 .table-of-contents__link[href="#terminal-operations"],

--- a/src/pages/cpdocs.js
+++ b/src/pages/cpdocs.js
@@ -129,7 +129,7 @@ function SdkTerminalTable() {
 
   return (
     <div>
-      <TableContainer>
+      <TableContainer style={{ overflowX: 'auto', width: '100%' }}>
         <Table align="center" sx={{ maxWidth: 1000 }} aria-label="simple table">
           <TableHead>
             <TableRow sx={{ height: 30 }}>
@@ -740,7 +740,7 @@ function CommunicationTypesTable() {
   return (
 
     <div>
-      <TableContainer >
+      <TableContainer style={{ overflowX: 'auto', width: '100%' }}>
         <Table align="center" sx={{ maxWidth: 1000 }} >
           <TableHead>
             <TableRow sx={{ maxHeight: 20 }}>


### PR DESCRIPTION
## Summary

- **Burger menu hidden on mobile**: MUI TableContainer relies on Emotion CSS for overflow-x: auto. Since Docusaurus pre-renders without MUI's Emotion SSR setup, the CSS isn't in the initial HTML. The 9-column SDK table renders at full content width (~800-1000px), widening the body beyond the viewport. Docusaurus sets overflow-x: hidden on the body, so the navbar stretches to match and the burger button is clipped off the right edge of the screen — invisible and inaccessible. Fixed by adding style={{ overflowX: 'auto', width: '100%' }} inline (not Emotion-dependent) on both TableContainer components.

- **Pills unresponsive on iOS Safari**: iOS Safari does not fire click events on non-interactive elements (li, div, span) unless cursor: pointer is applied directly to the element. The InfoTabs pills are <li onClick> elements with no such CSS. Fixed by adding cursor: pointer; touch-action: manipulation to .pills__item in custom.css.

## Files changed

- src/pages/cpdocs.js — overflowX: auto on both MUI TableContainer elements
- src/css/custom.css — .pills__item { cursor: pointer; touch-action: manipulation }

## Test plan

- [ ] Open developer.handpoint.io/com on a phone (iOS Safari and Android Chrome)
- [ ] Tap the burger menu icon — sidebar should open
- [ ] Tap Integration Paths, Standalone Options, and other pills — page should scroll to the section