### PR TITLE
docs: correct pre-auth increase/decrease semantics

### DIFF
--- a/docs/acquirers/epi.mdx
+++ b/docs/acquirers/epi.mdx
@@ -1685,7 +1685,7 @@ Supporting pre-auth means supporting the full lifecycle:
 | Operation | Description |
 |---|---|
 | **Create** | Place the initial hold |
-| **Increase / Decrease** | Adjust the held amount before capture |
+| **Increase / Decrease** | Adjust the held amount before capture — see the [Pre-Authorization Guide](/reference/pre-authorization-guide#increase-decrease) |
 | **Capture** | Finalise and charge the held amount |
 | **Pre-Auth Reversal** | Release the hold without charging (pre-capture) |
 | **Capture Reversal** | Cancel a completed capture (pre-settlement) — see separate section |
@@ -1694,7 +1694,7 @@ Supporting pre-auth means supporting the full lifecycle:
 
 1. A pre-auth creates an authorisation hold on the cardholder's account. Funds are not captured until you send a Capture.
 2. The hold typically expires after 7–30 days depending on the card network and issuer. Always capture or void before expiry.
-3. Increase / Decrease adjusts the amount before capture. Supported wherever pre-auth is supported.
+3. Increase / Decrease adjusts the hold with a **delta**, not a new total, and always references the original pre-auth `transactionID`. Not available on every acquirer — see the [Pre-Authorization Guide](/reference/pre-authorization-guide#increase-decrease).
 4. Always reverse unused pre-authorisations — unreleased holds affect the cardholder's available credit.
 
 :::note EPI

--- a/docs/acquirers/omnipay-emp.mdx
+++ b/docs/acquirers/omnipay-emp.mdx
@@ -1314,7 +1314,7 @@ Supporting pre-auth means supporting the full lifecycle:
 | Operation | Description |
 |---|---|
 | **Create** | Place the initial hold |
-| **Increase / Decrease** | Adjust the held amount before capture |
+| **Increase / Decrease** | Adjust the held amount before capture — see the [Pre-Authorization Guide](/reference/pre-authorization-guide#increase-decrease) |
 | **Capture** | Finalise and charge the held amount |
 | **Pre-Auth Reversal** | Release the hold without charging (pre-capture) |
 | **Capture Reversal** | Cancel a completed capture (pre-settlement) — see separate section |
@@ -1323,7 +1323,7 @@ Supporting pre-auth means supporting the full lifecycle:
 
 1. A pre-auth creates an authorisation hold on the cardholder's account. Funds are not captured until you send a Capture.
 2. The hold typically expires after 7–30 days depending on the card network and issuer. Always capture or void before expiry.
-3. Increase / Decrease adjusts the amount before capture. Supported wherever pre-auth is supported.
+3. Increase / Decrease adjusts the hold with a **delta**, not a new total, and always references the original pre-auth `transactionID`. Not available on every acquirer — see the [Pre-Authorization Guide](/reference/pre-authorization-guide#increase-decrease).
 4. Always reverse unused pre-authorisations — unreleased holds affect the cardholder's available credit.
 
 :::note EmerchantPay

--- a/docs/acquirers/omnipay-paystrax.mdx
+++ b/docs/acquirers/omnipay-paystrax.mdx
@@ -1313,7 +1313,7 @@ Supporting pre-auth means supporting the full lifecycle:
 | Operation | Description |
 |---|---|
 | **Create** | Place the initial hold |
-| **Increase / Decrease** | Adjust the held amount before capture |
+| **Increase / Decrease** | Adjust the held amount before capture — see the [Pre-Authorization Guide](/reference/pre-authorization-guide#increase-decrease) |
 | **Capture** | Finalise and charge the held amount |
 | **Pre-Auth Reversal** | Release the hold without charging (pre-capture) |
 | **Capture Reversal** | Cancel a completed capture (pre-settlement) — see separate section |
@@ -1322,7 +1322,7 @@ Supporting pre-auth means supporting the full lifecycle:
 
 1. A pre-auth creates an authorisation hold on the cardholder's account. Funds are not captured until you send a Capture.
 2. The hold typically expires after 7–30 days depending on the card network and issuer. Always capture or void before expiry.
-3. Increase / Decrease adjusts the amount before capture. Supported wherever pre-auth is supported.
+3. Increase / Decrease adjusts the hold with a **delta**, not a new total, and always references the original pre-auth `transactionID`. Not available on every acquirer — see the [Pre-Authorization Guide](/reference/pre-authorization-guide#increase-decrease).
 4. Always reverse unused pre-authorisations — unreleased holds affect the cardholder's available credit.
 
 :::note Paystrax

--- a/docs/acquirers/tsys-tns.mdx
+++ b/docs/acquirers/tsys-tns.mdx
@@ -1447,7 +1447,7 @@ Supporting pre-auth means supporting the full lifecycle:
 | Operation | Description |
 |---|---|
 | **Create** | Place the initial hold |
-| **Increase / Decrease** | Adjust the held amount before capture |
+| **Increase / Decrease** | Adjust the held amount before capture — see the [Pre-Authorization Guide](/reference/pre-authorization-guide#increase-decrease) |
 | **Capture** | Finalise and charge the held amount |
 | **Pre-Auth Reversal** | Release the hold without charging (pre-capture) |
 | **Capture Reversal** | Cancel a completed capture (pre-settlement) — see separate section |
@@ -1456,7 +1456,7 @@ Supporting pre-auth means supporting the full lifecycle:
 
 1. A pre-auth creates an authorisation hold on the cardholder's account. Funds are not captured until you send a Capture.
 2. The hold typically expires after 7–30 days depending on the card network and issuer. Always capture or void before expiry.
-3. Increase / Decrease adjusts the amount before capture. Supported wherever pre-auth is supported.
+3. Increase / Decrease adjusts the hold with a **delta**, not a new total, and always references the original pre-auth `transactionID`. Not available on every acquirer — see the [Pre-Authorization Guide](/reference/pre-authorization-guide#increase-decrease).
 4. Always reverse unused pre-authorisations — unreleased holds affect the cardholder's available credit.
 
 :::note PAYSAFE + Interac

--- a/docs/back-office/rest-api-no-reader.md
+++ b/docs/back-office/rest-api-no-reader.md
@@ -81,6 +81,25 @@ Content-Type: application/json
 }
 ```
 
+## Pre-Authorization Increase / Decrease
+
+Adjust the held amount on an open pre-authorization. No terminal or card interaction required.
+
+```http
+POST https://cloud.handpoint.com/preauthorization/increase
+ApiKeyCloud: YOUR_MERCHANT_API_KEY
+Content-Type: application/json
+
+{
+  "originalGuid": "01236fc0-8192-11eb-9aca-ad4b0e95f241",
+  "increaseAmount": "20.00"
+}
+```
+
+`increaseAmount` is the **delta** to add to the current hold, in major units — not the new total. Add `"subtract": "1"` to decrease instead; there is no separate decrease endpoint. `originalGuid` is always the `transactionID` of the original pre-authorization.
+
+See [Pre-Authorization Guide](/reference/pre-authorization-guide#increase-decrease) for the full rules, optional parameters, and the with-reader alternative.
+
 ## Pre-Authorization Capture
 
 Finalize a pre-authorization and charge the cardholder. No terminal or card interaction required — the capture is sent directly to the acquirer using the `transactionID` from the original pre-auth result.

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -30,17 +30,21 @@ description: Error codes returned by the Handpoint API and SDK, with recovery gu
 | `3153` | `Unable to find message to reverse.` | `originalGuid` not found | Verify the GUID is the `transactionID` from the original transaction result |
 | `4066` | `Partial reversal amount exceeds original amount` | `amount` exceeds the original transaction amount | Reduce amount or omit `amount` for a full reversal |
 
-## Error codes — `POST /preauthorization/capture` and `POST /preauthorization/increase`
+## Error codes — `POST /preauthorization/capture` and `POST /preauthorization/increase` {#pre-auth-adjustment}
 
-| `code` | `message` | Meaning | What to do |
+| `code` | HTTP | Meaning | What to do |
 |---|---|---|---|
-| `5001` | `NullPointerException` | `originalGuid` not found (internal error surfaced for unknown GUIDs on these endpoints) | Verify the GUID is the `transactionID` from the pre-auth create result |
-| `3211` | *(pre-auth already settled)* | Pre-auth has already been captured or voided — adjustment no longer possible | Check transaction state before sending an increase/decrease |
+| `3156` | `404` | No pre-authorization found for the `originalGuid` | Verify the GUID is the `transactionID` from the pre-auth create result |
+| `3207` | `400` | The referenced transaction is not a pre-authorization | Reference the Create, not an increase or a capture |
+| `3211` | `403` | The pre-authorization was declined, already captured, or already reversed | Check transaction state before adjusting or capturing |
+| `3212` | `403` | The decrease would take the hold to zero or below | Send a Pre-Auth Reversal to release the hold in full |
+| `3215` | `403` | The capture amount exceeds the current hold total | Increase the hold first, then capture |
+| `5001` | `400` | `NullPointerException` — internal error surfaced for unknown GUIDs on these endpoints | Verify the GUID is the `transactionID` from the pre-auth create result |
 
 :::note
-`POST /preauthorization/increase` handles both increases and decreases. To decrease, include `"subtract": "1"` in the request body — there is no separate `/preauthorization/decrease` endpoint.
+On `POST /preauthorization/increase` the amount field is `increaseAmount` (not `amount`) and takes a decimal major-unit string, e.g. `"20.00"`. Sending `amount` returns `422 VALIDATION_FAILED` with `details[].info.missingProperty: "increaseAmount"`.
 
-The amount field is `increaseAmount` (not `amount`) and takes a decimal major-unit string (e.g. `"20.00"`). Sending `amount` results in a `422 VALIDATION_FAILED` error with `details[].info.missingProperty: "increaseAmount"`.
+For how increases and decreases accumulate, which GUID to reference, and the per-path decrease signal, see the [Pre-Authorization Guide](/reference/pre-authorization-guide#increase-decrease).
 :::
 
 ## Transaction result `finStatus` values — with-reader operations

--- a/docs/reference/interac-void.md
+++ b/docs/reference/interac-void.md
@@ -19,6 +19,8 @@ The Handpoint gateway handles the protocol mapping automatically, but integrator
 2. What label to show in the ISV UI
 3. The constraint that the card must be present
 
+Interac also does **not support pre-authorization increase or decrease** — see [Increase or Decrease the hold](/reference/pre-authorization-guide#increase-decrease).
+
 ---
 
 ## SDK behaviour

--- a/docs/reference/javascript-sdk-setup.md
+++ b/docs/reference/javascript-sdk-setup.md
@@ -196,8 +196,8 @@ const preAuthTxnId = preAuth.eFTTransactionID;
 // Capture a pre-auth
 hp.preAuthorizationCapture(5000, 'USD', preAuthTxnId);
 
-// Increase a pre-auth hold before capture
-hp.preAuthorizationIncrease(6000, 'USD', preAuthTxnId);
+// Increase a pre-auth hold before capture — amount is the delta to add, not the new total
+hp.preAuthorizationIncrease(1000, 'USD', preAuthTxnId);
 
 // Void a pre-auth
 hp.preAuthorizationReversal(preAuthTxnId);
@@ -211,6 +211,8 @@ hp.tokenizeCard();
 // Sale + tokenise in one terminal interaction
 hp.saleAndTokenization(1250, 'USD');
 ```
+
+Pre-auth adjustments are cumulative deltas and always reference the original pre-auth ID — see the [Pre-Authorization Guide](/reference/pre-authorization-guide#increase-decrease).
 
 ### Tip adjustment
 

--- a/docs/reference/pre-authorization-guide.md
+++ b/docs/reference/pre-authorization-guide.md
@@ -137,16 +137,31 @@ handpoint.preAuthorization(
 
 ---
 
-## Step 2 — Increase or Decrease the hold (optional)
+## Step 2 — Increase or Decrease the hold (optional) {#increase-decrease}
 
-Adjusts the held amount before capture. Useful when the final amount changes — for example, room service added during a hotel stay.
+Adjusts the held amount before capture — for example, a hotel stay extended (increase) or a car rental returned early (decrease).
 
-- Send the **new total hold amount**, not a delta.
-- The operation links to the original pre-auth via `originalTransactionId`.
+**Adjustments are cumulative deltas, not new totals.** The gateway keeps one running hold amount per pre-authorization and applies each adjustment to it. To raise a $100 hold to $120, send $20 — not $120. Two increases of $50 and $75 on a $100 hold leave a $225 hold.
+
+- Always reference the **original** pre-authorization `transactionID`. Adjustments are never chained to a previous increase.
+- There is no separate decrease operation — a decrease is an increase carrying a decrease signal. The signal differs by integration path; see the tab for yours.
+- The result returns `holdAmount`, the running total after this adjustment. Use it to confirm the new hold rather than recalculating it yourself. `increaseAmount` echoes the delta you sent and `originalAmount` is the amount approved on the Create.
+- A declined adjustment leaves the hold unchanged.
+- The gateway applies no upper limit to an increase. The ceiling comes from the acquirer, the issuer, and the card-scheme tolerances in [Hold durations by card network](#hold-durations).
+- A decrease that would take the hold to zero or below is rejected. To release the hold entirely, send a [Pre-Auth Reversal](#pre-auth-reversal) instead.
+- Once the pre-authorization has been captured or reversed, no further adjustment is accepted.
 - Do **not** include a `transactionReference` — this is a subsequent operation.
+
+:::info Acquirer support
+Increase / Decrease is not available on every acquirer. Confirm support for your acquirer before relying on it.
+:::
 
 <Tabs groupId="integration-path">
 <TabItem value="cloud-api" label="Cloud API">
+
+Two paths are available.
+
+**With reader** — routes through the connected terminal. Amount in **minor units**; a **negative** amount decreases.
 
 ```http
 POST https://cloud.handpoint.com/transactions
@@ -155,7 +170,7 @@ Content-Type: application/json
 
 {
   "operation": "preAuthorizationIncrease",
-  "amount": "15000",
+  "amount": "2000",
   "currency": "USD",
   "terminal_type": "PAXA920",
   "serial_number": "082104578",
@@ -163,18 +178,45 @@ Content-Type: application/json
 }
 ```
 
-For a decrease, use the same operation with a lower `amount` value.
+To decrease, send `"amount": "-2000"`.
+
+**Without reader** — sent straight to the gateway, no terminal involved, result returned synchronously. Amount in **major units** as a decimal string and always positive; add `"subtract": "1"` to decrease.
+
+```http
+POST https://cloud.handpoint.com/preauthorization/increase
+ApiKeyCloud: YOUR_MERCHANT_API_KEY
+Content-Type: application/json
+
+{
+  "originalGuid": "01236fc0-8192-11eb-9aca-ad4b0e95f241",
+  "increaseAmount": "20.00"
+}
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `originalGuid` | string | Yes | `transactionID` from the pre-auth Create result |
+| `increaseAmount` | string | Yes | Delta in major units, e.g. `"20.00"`. Always positive — the field name applies to decreases too |
+| `subtract` | string | No | `"1"` subtracts the delta instead of adding it |
+| `tipAmount` | string | No | Tip in major units |
+| `taxAmount` | string | No | Tax in major units |
+| `customerReference` | string | No | Integrator-defined reference, forwarded as-is |
 
 </TabItem>
 <TabItem value="android-pax" label="Android (PAX)">
 
+Pass the delta in minor units. A **negative** value decreases.
+
 ```kotlin
-// Increase or decrease — pass the new total hold amount
+// Increase a $100 hold to $120
 hapi.preAuthorizationIncrease(
-    BigInteger("15000"),                            // new total hold amount
+    BigInteger("2000"),                             // delta, not the new total
     Currency.USD,
-    "01236fc0-8192-11eb-9aca-ad4b0e95f241"         // transactionID from original pre-auth
+    "01236fc0-8192-11eb-9aca-ad4b0e95f241"         // transactionID from the Create
 )
+
+// Decrease it back to $100
+hapi.preAuthorizationIncrease(BigInteger("-2000"), Currency.USD, "01236fc0-...")
 ```
 
 </TabItem>
@@ -193,7 +235,7 @@ Not supported on iOS HiLite.
 ```javascript
 handpoint.preAuthorizationIncrease(
   {
-    amount: 15000,
+    amount: 2000,                                   // delta in minor units; negative to decrease
     currency: "USD",
     originalTransactionID: "01236fc0-8192-11eb-9aca-ad4b0e95f241"
   },
@@ -205,11 +247,13 @@ handpoint.preAuthorizationIncrease(
 </TabItem>
 </Tabs>
 
+Adjustments are rejected with a dedicated error code when the pre-authorization has already been settled, or when a decrease would empty the hold — see [Error codes](/reference/error-codes#pre-auth-adjustment).
+
 ---
 
 ## Step 3a — Capture
 
-Finalizes the hold and charges the cardholder. Use the actual amount — it can be less than (or on some acquirers, slightly more than) the original hold.
+Finalizes the hold and charges the cardholder. Use the actual amount. It may be lower than the hold, but it must not exceed the current hold total — if the final charge is higher, [increase the hold](#increase-decrease) first.
 
 <Tabs groupId="integration-path">
 <TabItem value="cloud-api" label="Cloud API">
@@ -284,7 +328,7 @@ handpoint.preAuthorizationCapture(
 
 ---
 
-## Step 3b — Pre-Auth Reversal (release without capturing)
+## Step 3b — Pre-Auth Reversal (release without capturing) {#pre-auth-reversal}
 
 Releases the hold without charging the cardholder. Use when a booking is cancelled or the pre-auth is no longer needed.
 
@@ -337,7 +381,7 @@ handpoint.preAuthorizationReversal(
 
 ---
 
-## Step 4 — Capture Reversal (cancel a capture, pre-settlement)
+## Step 4 — Capture Reversal (cancel a capture, pre-settlement) {#capture-reversal}
 
 Cancels a capture that was sent in error — **before the batch closes and funds settle**. After settlement, only a Refund is possible.
 
@@ -427,7 +471,7 @@ ApiKeyCloud: YOUR_MERCHANT_API_KEY
     "finStatus": "AUTHORISED",
     "totalAmount": 9500,
     "transactionID": "e5f6a7b8-8192-11eb-9aca-ad4b0e95f241",
-    "originalEFTTransactionID": "a2b3c4d5-8192-11eb-9aca-ad4b0e95f241"
+    "originalEFTTransactionID": "01236fc0-8192-11eb-9aca-ad4b0e95f241"
   }
 ]
 ```
@@ -444,26 +488,29 @@ See [Transaction Recovery & Status](/reference/transaction-recovery) for full do
 |---|---|
 | Always reverse unused pre-auths | Unreleased holds reduce the cardholder's available credit and may generate disputes |
 | Capture before hold expiry (7–30 days) | Expired holds cannot be captured — you would need to re-initiate a new card interaction |
-| Store `transactionID` at every step | Capture and Void both require the `transactionID` from the most recent operation in the chain |
+| Store the Create `transactionID` | Every increase, decrease, capture, and reversal references the original pre-auth — not the most recent operation |
 | Store `transactionReference` from Create | Enables `/status/all` queries for the full chain at any time |
 | Do not send `transactionReference` on Capture, Increase, or Void | Only on the original Create. Subsequent operations are linked via `originalTransactionId` |
 | Partial capture is usually allowed | Capture less than the hold amount when the final charge is lower — no need to void and re-charge |
+| Increase before capturing more than the hold | A capture above the current hold total is rejected — raise the hold first |
+| Release a hold with a reversal, not a decrease | A decrease to zero is rejected; only a Pre-Auth Reversal releases the hold in full |
 | After settlement, use Refund — not Capture Reversal | Capture Reversal only works before the batch closes |
 
 ---
 
-## Quick reference — `transactionID` chain
+## Quick reference — which `transactionID` to send
 
-Each subsequent operation must reference the **most recent preceding operation** — not the original pre-auth:
+Every follow-up operation references the **original** pre-authorization — never a previous increase:
 
 ```
-Create         → transactionID = "A"
-Increase       → originalTransactionId = "A",  transactionID = "B"
-Second Increase → originalTransactionId = "B", transactionID = "C"
-Capture        → originalTransactionId = "C" (or "A" if no increases)
+Create            → transactionID = "A"
+Increase          → originalTransactionId = "A",  transactionID = "B"
+Second Increase   → originalTransactionId = "A",  transactionID = "C"
+Capture           → originalGuid = "A"
+Pre-Auth Reversal → originalTransactionId = "A"
 ```
 
-For the Cloud API Capture specifically, `originalGuid` always references the original pre-auth `transactionID`, not intermediate increases — confirm with your acquirer integration if in doubt.
+Capture Reversal is the one exception: it references the `transactionID` of the **Capture** result — see [Step 4](#capture-reversal).
 
 ---
 

--- a/docs/reference/pre-authorization-guide.md
+++ b/docs/reference/pre-authorization-guide.md
@@ -152,8 +152,13 @@ Adjusts the held amount before capture — for example, a hotel stay extended (i
 - Once the pre-authorization has been captured or reversed, no further adjustment is accepted.
 - Do **not** include a `transactionReference` — this is a subsequent operation.
 
-:::info Acquirer support
-Increase / Decrease is not available on every acquirer. Confirm support for your acquirer before relying on it.
+:::info Card brand and acquirer support
+Increase / Decrease is not available on every acquirer. Confirm support for yours before relying on it.
+
+Two card-brand rules apply on every route, whatever the headline acquirer:
+
+- **Interac** (Canadian debit) never supports increase or decrease. Interac authorizations are routed to a debit-only protocol that rejects the operation — see [Interac VOID](/reference/interac-void).
+- **Amex** cards do not support increase or decrease when the merchant holds a separate Amex agreement, because the card is routed to the Amex protocol.
 :::
 
 <Tabs groupId="integration-path">

--- a/docs/reference/windows-sdk-setup.md
+++ b/docs/reference/windows-sdk-setup.md
@@ -255,8 +255,8 @@ hapi.PreAuthorization(amount, Currency.USD);
 // Capture a pre-auth
 hapi.PreAuthorizationCapture(amount, Currency.USD, originalTransactionID: "TXN-PREAUTH");
 
-// Increase a pre-auth hold before capture
-hapi.PreAuthorizationIncrease(newAmount, Currency.USD, originalTransactionID: "TXN-PREAUTH");
+// Increase a pre-auth hold before capture — amount is the delta to add, not the new total
+hapi.PreAuthorizationIncrease(deltaAmount, Currency.USD, originalTransactionID: "TXN-PREAUTH");
 
 // Void a pre-auth
 hapi.PreAuthorizationReversal(originalTransactionID: "TXN-PREAUTH");
@@ -270,6 +270,8 @@ hapi.TokenizeCard();
 // Sale + tokenise in one terminal interaction
 hapi.SaleAndTokenizeCard(amount, Currency.USD);
 ```
+
+Pre-auth adjustments are cumulative deltas and always reference the original pre-auth ID — see the [Pre-Authorization Guide](/reference/pre-authorization-guide#increase-decrease).
 
 ### Tip adjustment
 

--- a/src/partials/functions/pre-auth-create.mdx
+++ b/src/partials/functions/pre-auth-create.mdx
@@ -13,7 +13,7 @@ Supporting pre-auth means supporting the full lifecycle:
 | Operation | Description |
 |---|---|
 | **Create** | Place the initial hold |
-| **Increase / Decrease** | Adjust the held amount before capture |
+| **Increase / Decrease** | Adjust the held amount before capture — see the [Pre-Authorization Guide](/reference/pre-authorization-guide#increase-decrease) |
 | **Capture** | Finalise and charge the held amount |
 | **Pre-Auth Reversal** | Release the hold without charging (pre-capture) |
 | **Capture Reversal** | Cancel a completed capture (pre-settlement) — see separate section |
@@ -22,7 +22,7 @@ Supporting pre-auth means supporting the full lifecycle:
 
 1. A pre-auth creates an authorisation hold on the cardholder's account. Funds are not captured until you send a Capture.
 2. The hold typically expires after 7–30 days depending on the card network and issuer. Always capture or void before expiry.
-3. Increase / Decrease adjusts the amount before capture. Supported wherever pre-auth is supported.
+3. Increase / Decrease adjusts the hold with a **delta**, not a new total, and always references the original pre-auth `transactionID`. Not available on every acquirer — see the [Pre-Authorization Guide](/reference/pre-authorization-guide#increase-decrease).
 4. Always reverse unused pre-authorisations — unreleased holds affect the cardholder's available credit.
 
 {/* ACQUIRER_NOTE_INJECTION_POINT */}


### PR DESCRIPTION
## What

The Pre-Authorization Guide documented increase/decrease incorrectly in three ways that would cost integrators real money:

| Doc said | Actually |
|---|---|
| Send the **new total** hold amount | Each request carries a **delta**; the gateway keeps one running hold and accumulates |
| `Second Increase → originalTransactionId = B` | Always the **original** pre-auth GUID — the gateway only links updates to `PREAUTHORIZATION_REQUEST` |
| Capture may be "slightly more than" the hold | A capture above the running total is rejected (`3215`) |

Following the old text, a $100 hold raised twice by $20 would have left a $140 hold, not $120.

## Where it lives

`docs/reference/pre-authorization-guide.md#increase-decrease` is now the single home for the mechanics. Everything else references it rather than repeating it:

- `error-codes.md` — adds the missing `3156` / `3207` / `3212` / `3215`; the inline mechanics note becomes a link
- `back-office/rest-api-no-reader.md` — the without-reader `POST /preauthorization/increase` endpoint was undocumented entirely
- acquirer pages + `pre-auth-create.mdx` partial — the "Increase / Decrease" bundle row now links out
- `javascript-sdk-setup.md` / `windows-sdk-setup.md` — snippets implied a new total (`6000` after a `5000` hold; `newAmount`)
- `interac-void.md` — points at the new Interac rule

Also newly documented: the `holdAmount` / `increaseAmount` / `originalAmount` response fields, the per-path decrease signal (negative amount with a reader vs `subtract: "1"` back-office), and that a decrease to exactly zero is rejected — only a reversal releases a hold in full.

Second commit adds two card-brand rules that hold on every route: **Interac never supports increase/decrease**, and **Amex doesn't when the merchant holds a separate Amex agreement**.

## Verification

`yarn build` passes. None of the new anchors are broken; the broken anchors the build reports are all pre-existing on `docs-v2`.

## Notes for the reviewer

- **Per-acquirer support is still unstated.** `TNS`, `Elavon`, `Amex`, `Borgun`, `EVO`, `GRV` and `PostBridge` reject increases outright, but the acquirer→protocol mapping lives in TMS agreement records, not in code — so I documented the two card-brand rules that are verifiable and left the acquirer claim hedged. Resolving it means reading the distinct `protocol` values on TMS agreements.
- **`src/partials/functions/pre-auth-increase.mdx` is orphaned** — it isn't in the generator's `pre-auth` bundle (`scripts/generate-acquirer-pages.js:22`), so it renders nowhere and now duplicates the guide. Needs a call: delete it, or wire it in and thin the guide. Left untouched here.
- **The committed acquirer pages are out of sync with the generator.** `yarn generate` produces ~700 lines of drift unrelated to this change (stale `_caps`, a removed Result block, MOTO tab restructuring), so I reverted it and applied the two changed lines directly to the four pages. The partial stays correct for a proper regeneration pass.
- **"EPI" may be a naming collision** — in the gateway, `EPI` is a BIN data source, not an acquirer or protocol. If our EPI page means an acquirer product, it's a different EPI, and its capability claims are worth a separate check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)